### PR TITLE
Add Binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# finding-bayesian-legos
+# Finding Bayesian Legos
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hankroark/finding-bayesian-legos/master?urlpath=lab/tree/1-ExperimentalApproach.ipynb)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # finding-bayesian-legos
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hankroark/finding-bayesian-legos/master?urlpath=lab/tree/1-ExperimentalApproach.ipynb)


### PR DESCRIPTION
@hankroark It would be great to have the Notebook be even more interactive by [Binderizing the repo](https://mybinder.org/). 

This PR adds Binder support by using Binder's [`requirements.txt` config API](https://mybinder.readthedocs.io/en/latest/config_files.html#requirements-txt-install-a-python-environment) to install all of the dependencies given in the [`requirements.txt` you provide](https://github.com/hankroark/finding-bayesian-legos/blob/0dcf8aaa1e8fda43a9e68df0d13f077a937b8694/requirements.txt) (very nicely, also! :+1:). By clicking the "launch Binder" badge in the `README` you can launch into a fully interactive Binder session of the `1-ExperimentalApproach.ipynb` with a Python 3 runtime that has the `requirements.txt` dependencies installed. Through some additional use of the API the session also opens up in a JupyterLab session (as opposed to the default Jupyter Notebook).

To try it now out you can click on this badge: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hankroark/finding-bayesian-legos/master?urlpath=lab/tree/1-ExperimentalApproach.ipynb)

If accepted I think that this can get squashed, as this is all essentially atomic.

Let me know if you have any questions or requested changes.